### PR TITLE
Use the `SecureValue` field for clientSecret

### DIFF
--- a/Auth0Token.js
+++ b/Auth0Token.js
@@ -37,7 +37,7 @@ Auth0Token.inputs = [
 	DynamicValueInput("userId", "User Id", "String"),
 	DynamicValueInput("email", "User Email", "String"),
 	DynamicValueInput("clientId", "Client ID", "String"),
-	DynamicValueInput("clientSecret", "Client Secret", "String")
+	DynamicValueInput("clientSecret", "Client Secret", "SecureValue")
 ]
 
 registerDynamicValueClass(Auth0Token);


### PR DESCRIPTION
In paw 2.3 we added the api so support "SecureValue" fields. This is the field you see in basic auth for example:

![image](https://cloud.githubusercontent.com/assets/838127/13330623/e8ac2574-dbf9-11e5-8c71-9bbbbaed20cf.png)
