### PR TITLE
removes base64 encoding of client secret

### DIFF
--- a/Auth0Token.js
+++ b/Auth0Token.js
@@ -1,27 +1,29 @@
-var jsrassign = require('./jsrassign');
+var jsrassign = require("./jsrassign");
 
 // Extensions are implemented as JavaScript classes
 var Auth0Token = function() {
-
   // implement the evaluate() method to generate the dynamic value
   this.evaluate = function() {
-    var now = Math.floor((new Date()).getTime() / 1000),
-    	headerInput = {
-			'typ': 'JWT',
-			'alg': 'HS256'
-		},
-    	bodyInput = {
-			'email': this.email,
-			'iss': this.issuer,
-			'sub': "auth0|" + this.userId,
-			'aud': this.clientId,
-			'exp': now + (60 * 60 * 24 * 7),
-			'iat': now
-		};
+    var now = Math.floor(new Date().getTime() / 1000),
+      headerInput = {
+        typ: "JWT",
+        alg: "HS256"
+      },
+      bodyInput = {
+        email: this.email,
+        iss: this.issuer,
+        sub: "auth0|" + this.userId,
+        aud: this.clientId,
+        exp: now + 60 * 60 * 24 * 7,
+        iat: now
+      };
 
-    return 'Bearer ' + jsrassign.jws.JWS.sign(null, headerInput, bodyInput, {b64: jsrassign.b64utob64(this.clientSecret)});
-  }
-}
+    return (
+      "Bearer " +
+      jsrassign.jws.JWS.sign(null, headerInput, bodyInput, this.clientSecret)
+    );
+  };
+};
 
 // set the Extension Identifier (must be same as the directory name)
 Auth0Token.identifier = "io.blackcode.Auth0Token";
@@ -33,11 +35,11 @@ Auth0Token.title = "Auth0 Authorization Token";
 Auth0Token.help = "https://github.com/LordZardeck/PAW-Auth0TokenDynamicValue";
 
 Auth0Token.inputs = [
-	DynamicValueInput("issuer", "Issuer", "String"),
-	DynamicValueInput("userId", "User Id", "String"),
-	DynamicValueInput("email", "User Email", "String"),
-	DynamicValueInput("clientId", "Client ID", "String"),
-	DynamicValueInput("clientSecret", "Client Secret", "SecureValue")
-]
+  DynamicValueInput("issuer", "Issuer", "String"),
+  DynamicValueInput("userId", "User Id", "String"),
+  DynamicValueInput("email", "User Email", "String"),
+  DynamicValueInput("clientId", "Client ID", "String"),
+  DynamicValueInput("clientSecret", "Client Secret", "SecureValue")
+];
 
 registerDynamicValueClass(Auth0Token);

--- a/Auth0Token.js
+++ b/Auth0Token.js
@@ -17,10 +17,12 @@ var Auth0Token = function() {
         exp: now + 60 * 60 * 24 * 7,
         iat: now
       };
+    secret = this.base64encoded
+      ? { b64: jsrassign.b64utob64(this.clientSecret) }
+      : this.clientSecret;
 
     return (
-      "Bearer " +
-      jsrassign.jws.JWS.sign(null, headerInput, bodyInput, this.clientSecret)
+      "Bearer " + jsrassign.jws.JWS.sign(null, headerInput, bodyInput, secret)
     );
   };
 };
@@ -39,7 +41,8 @@ Auth0Token.inputs = [
   DynamicValueInput("userId", "User Id", "String"),
   DynamicValueInput("email", "User Email", "String"),
   DynamicValueInput("clientId", "Client ID", "String"),
-  DynamicValueInput("clientSecret", "Client Secret", "SecureValue")
+  DynamicValueInput("clientSecret", "Client Secret", "SecureValue"),
+  DynamicValueInput("base64encoded", "Secret Base64 Encoded?", "Checkbox")
 ];
 
 registerDynamicValueClass(Auth0Token);


### PR DESCRIPTION
my formatter (prettier) automatically fixed up the formatting, but the only substantive change is the removal of base64 encoding from the secret when signing:

`{b64: jsrassign.b64utob64(this.clientSecret)}`

became:

`this.clientSecret`