### PR TITLE
updates field definition methods to match latest docs

### DIFF
--- a/Auth0Token.js
+++ b/Auth0Token.js
@@ -42,12 +42,12 @@ Auth0Token.title = "Auth0 Authorization Token";
 Auth0Token.help = "https://github.com/LordZardeck/PAW-Auth0TokenDynamicValue";
 
 Auth0Token.inputs = [
-  DynamicValueInput("issuer", "Issuer", "String"),
-  DynamicValueInput("userId", "User Id", "String"),
-  DynamicValueInput("email", "User Email", "String"),
-  DynamicValueInput("clientId", "Client ID", "String"),
-  DynamicValueInput("clientSecret", "Client Secret", "SecureValue"),
-  DynamicValueInput("base64encoded", "Secret Base64 Encoded?", "Checkbox")
+  InputField("issuer", "Issuer", "String"),
+  InputField("userId", "User Id", "String"),
+  InputField("email", "User Email", "String"),
+  InputField("clientId", "Client ID", "String"),
+  InputField("clientSecret", "Client Secret", "SecureValue"),
+  InputField("base64encoded", "Secret Base64 Encoded?", "Checkbox")
 ];
 
 registerDynamicValueClass(Auth0Token);


### PR DESCRIPTION
if you're interested, I changed the signatures to match the [latest documentation for input fields](https://paw.cloud/docs/extensions/input-fields) and everything appears to work the same. Not sure why it changed `DynamicValueInput` does not appear to be documented any longer, and while the patient is open...